### PR TITLE
Add distrib-core as dependency of rspec-distrib

### DIFF
--- a/rspec-distrib/Gemfile.lock
+++ b/rspec-distrib/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
   remote: .
   specs:
     rspec-distrib (0.0.1)
+      distrib-core
       rspec-core (~> 3.12)
 
 GEM

--- a/rspec-distrib/rspec-distrib.gemspec
+++ b/rspec-distrib/rspec-distrib.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.bindir = 'exe'
   s.executables = ['rspec-distrib']
 
+  s.add_dependency 'distrib-core'
   s.add_dependency 'rspec-core', '~> 3.12'
 
   s.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
Both [distrib-core](https://rubygems.org/gems/distrib-core) and [rspec-distrib](https://rubygems.org/gems/rspec-distrib) are published gems. That means we could finally express their relation in the gemspec.