### PR TITLE
[DEVX] Specify dependency version by using `~> 0.0.1`, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ This is a monorepo. Please follow to each gem's directory to get more insights.
 
 ## features-parser
 
-[features-parser](./features-parser/README.md) gems is a helper for cucumber-distrib runner. cucumber-distrib is not open-sourced.
+[features-parser](./features-parser/README.md) gem is a helper for cucumber-distrib runner. cucumber-distrib is not open-sourced.

--- a/rspec-distrib/Gemfile.lock
+++ b/rspec-distrib/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
   remote: .
   specs:
     rspec-distrib (0.0.1)
-      distrib-core
+      distrib-core (~> 0.0.1)
       rspec-core (~> 3.12)
 
 GEM

--- a/rspec-distrib/rspec-distrib.gemspec
+++ b/rspec-distrib/rspec-distrib.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.bindir = 'exe'
   s.executables = ['rspec-distrib']
 
-  s.add_dependency 'distrib-core'
+  s.add_dependency 'distrib-core', '~> 0.0.1'
   s.add_dependency 'rspec-core', '~> 3.12'
 
   s.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
I missed comment at https://github.com/toptal/test-distrib/pull/13/files#r1642201948.
Let specify the version.